### PR TITLE
Remove "disable ssl" suggestion from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,6 @@ Target system: arm-angstrom-linux-gnueabi
 	git clone https://github.com/pgmmpk/beaglebone_pru_adc.git
 	```
 	
-	Note: if GIT refuses to clone, this might help (warning: disabling GIT SSL verification may pose a security risk)
-	```bash
-	git config --global http.sslVerify false
-	```
-
 3. Build and install python package
 	```bash
 	cd beaglebone_pru_adc


### PR DESCRIPTION
Although I appreciate that you have taken the care to help new git users when they run into issues, suggesting that they disable SSL verification is a really never a good idea, and I think you recognize this yourself in your warning "(warning: disabling GIT SSL verification may pose a security risk)"

However, many new users who see the an error message when they clone will immediately copy your fix to disable ssl without looking to deeply at the error message which may be completely unrelated (permissions error, ect.). When that still doesn't work, they will probably then research a bit more online, solve their problem, and promptly forget that they just globally disabled SSL verification for every git interaction.

Lastly, SSL verification issues are indicative that your computer's network or SSL root certificate configuration is very faulty and perhaps has been compromised.  Github uses an EV cert issued by a very well known CA `DigiCert SHA2 Extended Validation Server CA`  so this shouldn't be something that happens on a properly secured and clean computer.

Thanks for reading this far :) Its a great project you maintain here!
